### PR TITLE
Sensor unavailable after restart fix

### DIFF
--- a/Bed_Sensor/Bed_Sensor.ino
+++ b/Bed_Sensor/Bed_Sensor.ino
@@ -76,9 +76,9 @@ void loop() {
 void reconnect() {
   while (!client.connected()) {       // Loop until connected to MQTT server
     Serial.print("Attempting MQTT connection...");
-    if (client.connect(HOSTNAME, mqtt_username, mqtt_password)) {       //Connect to MQTT server
+    if (client.connect(HOSTNAME, mqtt_username, mqtt_password, AVAILABILITY_TOPIC, 2, true, "offline")) {       //Connect to MQTT server
       Serial.println("connected"); 
-      client.publish(AVAILABILITY_TOPIC, "online");         // Once connected, publish online to the availability topic
+      client.publish(AVAILABILITY_TOPIC, "online", true);         // Once connected, publish online to the availability topic
       client.subscribe(TARE_TOPIC);       //Subscribe to tare topic for remote tare
     } else {
       Serial.print("failed, rc=");


### PR DESCRIPTION
Hi had a problem with the sensor not showing up in Home Assistant after a restart. so i asked for help [here ](https://community.home-assistant.io/t/mqtt-sensor-unavailable-after-restart-fixed/352254/3?u=roschi02). Now i just want to share the changes in the code for the possibility that someone else has the same problem.